### PR TITLE
Improved performance and removed deprecation of GH workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,19 @@ jobs:
         with:
           go-version: 1.18.x
           cache: true
-      - name: Run go lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.0
-          $(go env GOPATH)/bin/golangci-lint run --timeout=5m -c .golangci.yml
+      - name: Run golangci-lint
+        # run: |
+        #   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.0
+        #   $(go env GOPATH)/bin/golangci-lint run --timeout=5m -c .golangci.yml
+        uses: golangci/golangci-lint-action@v3
+        ### golangci-lint will take much time if loading multiple linters in .golangci.yml
+        with:
+          version: v1.50.0
+          args: --timeout 3m --verbose
+          skip-cache: false
+          skip-pkg-cache: false
+          skip-build-cache: false
+          only-new-issues: true
 
   test:
     # matrix strategy from: https://github.com/mvdan/github-actions-golang/blob/master/.github/workflows/test.yml
@@ -66,7 +75,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            vocdoni/${{ github.event.repository.name }}:latest, vocdoni/${{ github.event.repository.name }}:${{ steps.var.outputs.branch_name }},
-            ghcr.io/vocdoni/${{ github.event.repository.name }}:latest, ghcr.io/vocdoni/${{ github.event.repository.name }}:${{ steps.var.outputs.branch_name }}
+            vocdoni/${{ github.event.repository.name }}:latest, vocdoni/${{ github.event.repository.name }}:${{ steps.vars.outputs.branch_name }},
+            ghcr.io/vocdoni/${{ github.event.repository.name }}:latest, ghcr.io/vocdoni/${{ github.event.repository.name }}:${{ steps.vars.outputs.branch_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Many changes:
1. action/setup-go@v1 to v3 and activate cache
2. actions/checkout@v2 to v3
3. docker/setup-buildx-action@v1 to v2
4. docker/login-action@v1 to v2
5. replaced deprecated set-output for echo and $GITHUB_OUTPUT
6. docker/build-push-action@v2 to v3 and activate cache
7. replace golangci-lint installation and execution by golangci/golangci-lint-action@v3
