### PR TITLE
vocdoni: change response faucetPackage format

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -223,7 +223,7 @@ func (a *API) evmFaucetHandler(ctx *httprouter.HTTPContext,
 	}
 	resp := &FaucetResponse{
 		TxHash: types.HexBytes(txHash.Bytes()),
-		Amount: a.evmFaucet.Amout().String(),
+		Amount: fmt.Sprint(a.evmFaucet.Amout()),
 	}
 	msg, err := json.Marshal(resp)
 	if err != nil {
@@ -249,7 +249,7 @@ func (a *API) vocdoniFaucetHandler(ctx *httprouter.HTTPContext,
 		return err
 	}
 	resp := &FaucetResponse{
-		Amount: a.vocdoniFaucet.Amount().String(),
+		Amount: fmt.Sprint(a.vocdoniFaucet.Amount()),
 		FaucetPackage: &FaucetPackage{
 			FaucetPayload: faucetPayloadBytes,
 			Signature:     faucetPackage.Signature,

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -80,6 +80,7 @@ func TestAPI(t *testing.T) {
 	resp, code := c.request("GET", nil, "vocdoni", "dev", randomEVMAddress.Hex())
 	qt.Assert(t, code, qt.Equals, 200)
 	respData := &faucetapi.FaucetResponse{}
+	t.Logf("response: %x", resp)
 	qt.Assert(t, json.Unmarshal(resp, &respData), qt.IsNil)
 	faucetPayloadData := &models.FaucetPayload{}
 	qt.Assert(t, json.Unmarshal(respData.FaucetPackage.FaucetPayload, faucetPayloadData), qt.IsNil)
@@ -116,7 +117,7 @@ func TestAPI(t *testing.T) {
 
 	// create ethereum request
 	resp, code = c.request("GET", nil, "evm", "evmtest", randomEVMAddress.String())
-	// make the test blockchain to mine a block
+	t.Logf("response: %x", resp)
 	qt.Assert(t, code, qt.Equals, 200)
 	respData = &faucetapi.FaucetResponse{}
 	qt.Assert(t, json.Unmarshal(resp, &respData), qt.IsNil)

--- a/faucet/common.go
+++ b/faucet/common.go
@@ -35,7 +35,7 @@ const (
 )
 
 var (
-	MAXINT64 = int64(9223372036854775807)
+	MAXUINT64 = uint64(9223372036854775807)
 	// ErrInvalidEndpoint error wrapping invalid endpoint errors
 	ErrInvalidEndpoint error = errors.New("invalid endpoint")
 	// ErrInvalidAmount error wrapping invalid amount errors

--- a/faucet/evm.go
+++ b/faucet/evm.go
@@ -25,7 +25,7 @@ type EVM struct {
 	// chainID chainId/networkId of the network
 	chainID int
 	// amount of tokens to be transferred
-	amount *big.Int
+	amount uint64
 	// endpoints to connect with
 	endpoints []string
 	// client client instance connected to an endpoint
@@ -49,7 +49,7 @@ func NewEVM() *EVM {
 }
 
 // Amount returns the amount for the faucet
-func (e *EVM) Amout() *big.Int {
+func (e *EVM) Amout() uint64 {
 	e.lock.RLock()
 	defer e.lock.RUnlock()
 	return e.amount
@@ -79,10 +79,10 @@ func (e *EVM) setSendConditions(balance uint64, challenge bool) {
 }
 
 // SetAmount sets the amount for the faucet
-func (e *EVM) SetAmount(amount *big.Int) error {
+func (e *EVM) SetAmount(amount uint64) error {
 	e.lock.Lock()
 	defer e.lock.Unlock()
-	if amount.Cmp(big.NewInt(0)) == 0 {
+	if amount == 0 {
 		return ErrInvalidAmount
 	}
 	e.amount = amount
@@ -141,7 +141,7 @@ func (e *EVM) Init(ctx context.Context, evmConfig *config.FaucetConfig) error {
 	}
 
 	// set amout to transfer
-	if err := e.SetAmount(big.NewInt(int64(evmConfig.EVMAmount))); err != nil {
+	if err := e.SetAmount(evmConfig.EVMAmount); err != nil {
 		return ErrInvalidAmount
 	}
 
@@ -301,7 +301,7 @@ func (e *EVM) sendTokens(ctx context.Context,
 		GasTipCap: maxPriorityFeePerGas,
 		Gas:       uint64(21000), // enough for standard eth transfers
 		To:        &to,
-		Value:     e.amount, // in wei
+		Value:     big.NewInt(int64(e.amount)), // in wei
 	})
 	// sign tx
 	signedTx, err := evmtypes.SignTx(tx,

--- a/faucet/evm.go
+++ b/faucet/evm.go
@@ -25,7 +25,7 @@ type EVM struct {
 	// chainID chainId/networkId of the network
 	chainID int
 	// amount of tokens to be transferred
-	amount uint64
+	amount *big.Int
 	// endpoints to connect with
 	endpoints []string
 	// client client instance connected to an endpoint
@@ -49,7 +49,7 @@ func NewEVM() *EVM {
 }
 
 // Amount returns the amount for the faucet
-func (e *EVM) Amout() uint64 {
+func (e *EVM) Amout() *big.Int {
 	e.lock.RLock()
 	defer e.lock.RUnlock()
 	return e.amount
@@ -79,10 +79,10 @@ func (e *EVM) setSendConditions(balance uint64, challenge bool) {
 }
 
 // SetAmount sets the amount for the faucet
-func (e *EVM) SetAmount(amount uint64) error {
+func (e *EVM) SetAmount(amount *big.Int) error {
 	e.lock.Lock()
 	defer e.lock.Unlock()
-	if amount == 0 && amount == e.amount {
+	if amount.Cmp(big.NewInt(0)) == 0 {
 		return ErrInvalidAmount
 	}
 	e.amount = amount
@@ -141,7 +141,7 @@ func (e *EVM) Init(ctx context.Context, evmConfig *config.FaucetConfig) error {
 	}
 
 	// set amout to transfer
-	if err := e.SetAmount(evmConfig.EVMAmount); err != nil {
+	if err := e.SetAmount(big.NewInt(int64(evmConfig.EVMAmount))); err != nil {
 		return ErrInvalidAmount
 	}
 
@@ -301,7 +301,7 @@ func (e *EVM) sendTokens(ctx context.Context,
 		GasTipCap: maxPriorityFeePerGas,
 		Gas:       uint64(21000), // enough for standard eth transfers
 		To:        &to,
-		Value:     big.NewInt(int64(e.amount)), // in wei
+		Value:     e.amount, // in wei
 	})
 	// sign tx
 	signedTx, err := evmtypes.SignTx(tx,

--- a/faucet/faucet_test.go
+++ b/faucet/faucet_test.go
@@ -2,7 +2,6 @@ package faucet_test
 
 import (
 	"context"
-	"math/big"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -128,9 +127,9 @@ func TestSendTokens(t *testing.T) {
 		"f3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 	}), qt.IsNil)
 	// send tokens to new signer
-	qt.Assert(t, e.SetAmount(big.NewInt(1079853350110000)), qt.IsNil)
+	qt.Assert(t, e.SetAmount(1079853350110000), qt.IsNil)
 	_, err = e.SendTokens(context.Background(), newSigner.Address())
-	qt.Assert(t, e.SetAmount(big.NewInt(100)), qt.IsNil)
+	qt.Assert(t, e.SetAmount(100), qt.IsNil)
 	qt.Assert(t, err, qt.IsNil)
 	e.TestBackend().Backend.Commit() // save ethereum state
 	// expected to use two different signers
@@ -182,7 +181,7 @@ func TestGenerateFaucet(t *testing.T) {
 	qt.Assert(t, toAddr.Generate(), qt.IsNil)
 	faucetPackage, err := v.GenerateFaucetPackage(toAddr.Address())
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, faucetPackage.Payload.Amount, qt.DeepEquals, v.Amount().Uint64())
+	qt.Assert(t, faucetPackage.Payload.Amount, qt.DeepEquals, v.Amount())
 	qt.Assert(t, faucetPackage.Payload.To, qt.DeepEquals, toAddr.Address().Bytes())
 	protoBytes, err := proto.Marshal(faucetPackage.Payload)
 	qt.Assert(t, err, qt.IsNil)

--- a/faucet/faucet_test.go
+++ b/faucet/faucet_test.go
@@ -2,6 +2,7 @@ package faucet_test
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -127,9 +128,9 @@ func TestSendTokens(t *testing.T) {
 		"f3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 	}), qt.IsNil)
 	// send tokens to new signer
-	qt.Assert(t, e.SetAmount(1079853350110000), qt.IsNil)
+	qt.Assert(t, e.SetAmount(big.NewInt(1079853350110000)), qt.IsNil)
 	_, err = e.SendTokens(context.Background(), newSigner.Address())
-	qt.Assert(t, e.SetAmount(100), qt.IsNil)
+	qt.Assert(t, e.SetAmount(big.NewInt(100)), qt.IsNil)
 	qt.Assert(t, err, qt.IsNil)
 	e.TestBackend().Backend.Commit() // save ethereum state
 	// expected to use two different signers
@@ -181,7 +182,7 @@ func TestGenerateFaucet(t *testing.T) {
 	qt.Assert(t, toAddr.Generate(), qt.IsNil)
 	faucetPackage, err := v.GenerateFaucetPackage(toAddr.Address())
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, faucetPackage.Payload.Amount, qt.DeepEquals, v.Amount())
+	qt.Assert(t, faucetPackage.Payload.Amount, qt.DeepEquals, v.Amount().Uint64())
 	qt.Assert(t, faucetPackage.Payload.To, qt.DeepEquals, toAddr.Address().Bytes())
 	protoBytes, err := proto.Marshal(faucetPackage.Payload)
 	qt.Assert(t, err, qt.IsNil)

--- a/faucet/vocdoni.go
+++ b/faucet/vocdoni.go
@@ -20,7 +20,7 @@ type Vocdoni struct {
 	// networkID one of the Vocdoni networks
 	networkID string
 	// amount of tokens to include
-	amount *big.Int
+	amount uint64
 	// signer account that will be used for signing
 	signer *ethereum.SignKeys
 	// sendConditions conditions to meet before executing an action
@@ -33,7 +33,7 @@ func NewVocdoni() *Vocdoni {
 }
 
 // Amount returns amount
-func (v *Vocdoni) Amount() *big.Int {
+func (v *Vocdoni) Amount() uint64 {
 	return v.amount
 }
 
@@ -47,8 +47,8 @@ func (v *Vocdoni) Network() string {
 	return v.network
 }
 
-func (v *Vocdoni) setAmount(amount *big.Int) error {
-	if amount.Cmp(big.NewInt(0)) == 0 {
+func (v *Vocdoni) setAmount(amount uint64) error {
+	if amount == 0 {
 		return ErrInvalidAmount
 	}
 	v.amount = amount
@@ -73,7 +73,7 @@ func (v *Vocdoni) Init(ctx context.Context, vocdoniConfig *config.FaucetConfig) 
 	v.networkID = chainSpecs.networkID
 
 	// set amout to transfer
-	if err := v.setAmount(big.NewInt(int64(vocdoniConfig.VocdoniAmount))); err != nil {
+	if err := v.setAmount(vocdoniConfig.VocdoniAmount); err != nil {
 		return err
 	}
 
@@ -94,14 +94,14 @@ func (v *Vocdoni) Init(ctx context.Context, vocdoniConfig *config.FaucetConfig) 
 
 // GenerateFaucetPackage generates a faucet package
 func (v *Vocdoni) GenerateFaucetPackage(address evmcommon.Address) (*models.FaucetPackage, error) {
-	identifier, err := rand.Int(rand.Reader, big.NewInt(MAXINT64))
+	identifier, err := rand.Int(rand.Reader, big.NewInt(int64(MAXUINT64)))
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate faucet package identifier")
 	}
 	return vochain.GenerateFaucetPackage(
 		v.signer,
 		address,
-		v.amount.Uint64(),
+		v.amount,
 		identifier.Uint64(),
 	)
 }

--- a/faucet/vocdoni.go
+++ b/faucet/vocdoni.go
@@ -20,7 +20,7 @@ type Vocdoni struct {
 	// networkID one of the Vocdoni networks
 	networkID string
 	// amount of tokens to include
-	amount uint64
+	amount *big.Int
 	// signer account that will be used for signing
 	signer *ethereum.SignKeys
 	// sendConditions conditions to meet before executing an action
@@ -33,7 +33,7 @@ func NewVocdoni() *Vocdoni {
 }
 
 // Amount returns amount
-func (v *Vocdoni) Amount() uint64 {
+func (v *Vocdoni) Amount() *big.Int {
 	return v.amount
 }
 
@@ -47,8 +47,8 @@ func (v *Vocdoni) Network() string {
 	return v.network
 }
 
-func (v *Vocdoni) setAmount(amount uint64) error {
-	if amount == 0 && amount == v.amount {
+func (v *Vocdoni) setAmount(amount *big.Int) error {
+	if amount.Cmp(big.NewInt(0)) == 0 {
 		return ErrInvalidAmount
 	}
 	v.amount = amount
@@ -73,7 +73,7 @@ func (v *Vocdoni) Init(ctx context.Context, vocdoniConfig *config.FaucetConfig) 
 	v.networkID = chainSpecs.networkID
 
 	// set amout to transfer
-	if err := v.setAmount(vocdoniConfig.VocdoniAmount); err != nil {
+	if err := v.setAmount(big.NewInt(int64(vocdoniConfig.VocdoniAmount))); err != nil {
 		return err
 	}
 
@@ -101,7 +101,7 @@ func (v *Vocdoni) GenerateFaucetPackage(address evmcommon.Address) (*models.Fauc
 	return vochain.GenerateFaucetPackage(
 		v.signer,
 		address,
-		v.amount,
+		v.amount.Uint64(),
 		identifier.Uint64(),
 	)
 }


### PR DESCRIPTION
- **Old**: 

```json
{
    "amount": <number>,
    "faucetPayload": <protobuf encoded bytes>,
    "signature": <hexBytes>
}
```

- **New**:

```json
{
    "amount": <string>,
    "faucetPackage": <bytes>"
}
```
Content of `"faucetPackage"`:
```json
{
    "faucetPackage":  {
        "faucetPayload": <bytes>,
        "signature": <bytes>"
    }
}
```

_`<bytes>` -> standard JSON b64 encoding_